### PR TITLE
Introduce exact matching

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    processIsolation="false"
+    bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Dflydev/Stack/Firewall.php
+++ b/src/Dflydev/Stack/Firewall.php
@@ -15,14 +15,14 @@ class Firewall implements HttpKernelInterface
     public function __construct(HttpKernelInterface $app, array $options = [])
     {
         $this->app = $app;
-        $this->firewall = $options['firewall'];
+        $this->matcher = new Firewall\Matcher($options['firewall']);
         unset($options['firewall']);
         $this->options = $options;
     }
 
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        $firewall = static::matchFirewall($request, $this->firewall);
+        $firewall = $this->matcher->match($request);
 
         if (null === $firewall) {
             // If no firewall is matched we can delegate immediately.
@@ -42,45 +42,4 @@ class Firewall implements HttpKernelInterface
             ->handle($request, $type, $catch);
     }
 
-    /**
-     * Left public currently so we can test this by itself; eventually would
-     * maybe like to make this a service that can be swapped out via
-     * configuration? Not sure what to do with it, really.
-     */
-    public static function matchFirewall(Request $request, array $firewalls)
-    {
-        if (!$firewalls) {
-            // By default we should firewall the root request and not allow
-            // anonymous requests. (will force challenge immediately)
-            $firewalls = [
-                ['path' => '/']
-            ];
-        }
-
-        $sortedFirewalls = [];
-        foreach ($firewalls as $firewall) {
-            if (!isset($firewall['anonymous'])) {
-                $firewall['anonymous'] = false;
-            }
-
-            if (isset($sortedFirewalls[$firewall['path']])) {
-                throw new \InvalidArgumentException("Path '".$firewall['path']."' specified more than one time.");
-            }
-
-            $sortedFirewalls[$firewall['path']] = $firewall;
-        }
-
-        // We want to sort things by more specific paths first. This will
-        // ensure that for instance '/' is never captured before any other
-        // firewalled paths.
-        krsort($sortedFirewalls);
-
-        foreach ($sortedFirewalls as $path => $firewall) {
-            if (0 === strpos($request->getPathInfo(), $path)) {
-                return $firewall;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/Dflydev/Stack/Firewall/Matcher.php
+++ b/src/Dflydev/Stack/Firewall/Matcher.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Dflydev\Stack\Firewall;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Matcher
+{
+    private $firewalls = [];
+
+    public function __construct(array $firewalls)
+    {
+        if (!$firewalls) {
+            // By default we should firewall the root request and not allow
+            // anonymous requests. (will force challenge immediately)
+            $firewalls = [
+                ['path' => '/']
+            ];
+        }
+
+        foreach ($firewalls as $firewall) {
+            // Set default values
+            $firewall = $firewall + [
+                'anonymous' => false,
+                'exact_match' => false,
+                'method' => null
+            ];
+            $this->firewalls[] = $firewall;
+        }
+
+        // We want to sort things by more specific paths first. This will
+        // ensure that for instance '/' is never captured before any other
+        // firewalled paths.
+        uasort($this->firewalls, function($a, $b) {
+            if ($a['path'] === $b['path']) {
+                return 0;
+            }
+            return -($a > $b ? 1 : -1);
+        });
+    }
+
+    /**
+     * Find the matching path
+     */
+    public function match(Request $request)
+    {
+        foreach ($this->firewalls as $firewall) {
+            if ($firewall['method'] !== null && $request->getMethod() !== $firewall['method']) {
+                continue;
+            }
+
+            if ($firewall['exact_match']) {
+                if ($request->getPathInfo() === $firewall['path']) {
+                    return $firewall;
+                }
+            } elseif (0 === strpos($request->getPathInfo(), $firewall['path'])) {
+                return $firewall;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+$loader = require __DIR__ . '/../vendor/autoload.php';
+$loader->add('unit\\', __DIR__);
+$loader->add('functional\\', __DIR__);

--- a/tests/unit/MatcherTest.php
+++ b/tests/unit/MatcherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace unit;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class MatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPathMatching()
+    {
+        $this->matcher = new \Dflydev\Stack\Firewall\Matcher([
+            ['path' => '/'],
+            ['path' => '/users/', 'exact_match' => true],
+            ['path' => '/messages/', 'method' => 'POST'],
+            ['path' => '/cats/', 'method' => 'PUT', 'exact_match' => true],
+        ]);
+
+        $this->assertMatch('/', Request::create('/test'));
+        $this->assertMatch('/', Request::create('/'));
+
+        $this->assertMatch('/users/', Request::create('/users/'));
+        $this->assertMatch('/',      Request::create('/users/123')); // no matching for exact_match
+
+        $this->assertMatch('/messages/', Request::create('/messages/123', 'POST'));
+        $this->assertMatch('/messages/', Request::create('/messages/',    'POST'));
+        $this->assertMatch('/',          Request::create('/messages/',    'GET'));
+
+        $this->assertMatch('/cats/', Request::create('/cats/',    'PUT'));
+        $this->assertMatch('/',      Request::create('/cats/123', 'PUT'));
+        $this->assertMatch('/',      Request::create('/cats/',    'DELETE'));
+        $this->assertMatch('/',      Request::create('/cats/123', 'DELETE'));
+    }
+
+    public function testNotMatching()
+    {
+        $matcher = new \Dflydev\Stack\Firewall\Matcher([['path' => '/api/']]);
+        $this->assertNull($matcher->match(Request::create('/blah')));
+    }
+
+    public function testSpecificMethodMatchingOrder()
+    {
+        $this->matcher = new \Dflydev\Stack\Firewall\Matcher([
+            ['path' => '/users/', 'method' => 'POST'],
+            ['path' => '/users/'],
+        ]);
+
+        $this->assertMatch('/users/', Request::create('/users/123'));
+    }
+
+    protected function assertMatch($expected, $request)
+    {
+        $this->assertEquals($expected, $this->matcher->match($request)['path']);
+    }
+}


### PR DESCRIPTION
The use case:
I have a POST '/users/' method which should be anonymous. However POST '/users/123' should NOT.

Solution: introduce "exact_match" options to the firewall i.e.

``` php
$kernel = (new \Stack\Builder())
            ->push('Dflydev\Stack\BasicAuthentication', [
                'firewall' => [
                    ['path' => '/'],
                    ['path' => '/users/', 'exact_match' => true, 'method' => 'POST', 'anonymous' => true],
                ],
                'authenticator' => $auth,
                'realm' => '...',
            ])
            ->resolve($app);
```

Would you accept the PR?
