### PR TITLE
Correct path comparison in matcher

### DIFF
--- a/src/Dflydev/Stack/Firewall/Matcher.php
+++ b/src/Dflydev/Stack/Firewall/Matcher.php
@@ -35,7 +35,7 @@ class Matcher
             if ($a['path'] === $b['path']) {
                 return 0;
             }
-            return -($a > $b ? 1 : -1);
+            return -($a['path'] > $b['path'] ? 1 : -1);
         });
     }
 


### PR DESCRIPTION
The comparison that happens while sorting firewalls is incorrect. This PR fixes this by correctly comparing the paths instead of the whole firewall definition (which is an array).